### PR TITLE
 v1.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/url",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "URL manipulation library",
   "homepage": "https://github.com/CodeIncHQ/Url",
   "type": "library",

--- a/src/Url.php
+++ b/src/Url.php
@@ -545,12 +545,22 @@ class Url implements UrlInterface
 
     /**
      * @inheritdoc
+     * @param iterable|null $parameters Parameters to be removed
      * @return static
      */
-    public function withoutQuery():UrlInterface
+    public function withoutQuery(?iterable $parameters = null):UrlInterface
     {
         $url = clone $this;
-        $url->setQuery(null);
+        $query = [];
+        if ($parameters !== null) {
+            $query = $url->getQueryAsArray();
+            foreach ($parameters as $param) {
+                if (array_key_exists($param, $query)) {
+                    unset($query[$param]);
+                }
+            }
+        }
+        $url->setQuery($query);
         return $url;
     }
 

--- a/src/UrlInterface.php
+++ b/src/UrlInterface.php
@@ -191,9 +191,10 @@ interface UrlInterface extends UriInterface
     /**
      * Returns the URL without a query string.
      *
+     * @param iterable|null $parameters Parameters to be removed
      * @return static
      */
-    public function withoutQuery():UrlInterface;
+    public function withoutQuery(?iterable $parameters = null):UrlInterface;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
* `UrlInterface::withoutQuery()` now accepts a parameters list